### PR TITLE
Release 0.2.0: heredoc shell parsing, bundled skill, contrib snippets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "permiter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "permiter"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "An iptables-inspired PreToolUse hook for Claude Code"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ permiter supports two config formats. The file extension determines the parser:
 - **`.perm`** — a purpose-built DSL (recommended, more concise)
 - **`.toml`** — standard TOML (more verbose, better editor support)
 
-Both formats produce the same internal config. See [`example.perm`](example.perm) and [`example.toml`](example.toml) for equivalent reference configs.
+Both formats produce the same internal config. See [`example.perm`](example.perm) and [`example.toml`](example.toml) for equivalent reference configs, and [`contrib/`](contrib/) for ready-made snippets (kubectl, git, scripting venvs, MCP allowlists, …) you can lift into your own config.
 
 ---
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,63 @@
+# contrib/
+
+Copy-pasteable rule snippets for common workflows. These are **not**
+standalone configs — they're fragments meant to be lifted into your
+own `permiter.perm` (typically `~/.config/permiter.perm`).
+
+Each file has a header comment with:
+- What it does
+- Where it goes (which table, or top-level)
+- Variables it expects you to define (or that it defines)
+
+## Files
+
+| File | What |
+|------|------|
+| [injection-guards.perm](injection-guards.perm) | Newline-in-arg, sudo, ssh denies — defensive baseline |
+| [shell-wrappers.perm](shell-wrappers.perm) | `evaluate` rules for `sh -c`, `timeout`, `xargs`, `nice`, `env`… |
+| [git-safe.perm](git-safe.perm) | Read-only git subcommands + a `git_worktree` sub-table |
+| [kubectl-readonly.perm](kubectl-readonly.perm) | Allow `kubectl get/describe/logs/...`, passthrough mutations |
+| [scripting-venv.perm](scripting-venv.perm) | Allow `pip`/`python`/`npm`/`node`/`bun` only when project venv/lockfile is present |
+| [curl-restricted.perm](curl-restricted.perm) | Allow `curl` only to localhost or read-only GitHub API |
+| [systemctl-readonly.perm](systemctl-readonly.perm) | Allow `systemctl status/show/list-*`, passthrough mutations |
+| [mcp-common-allowlist.perm](mcp-common-allowlist.perm) | Allow popular read-only MCP servers by tool-name prefix |
+
+## How to combine
+
+A typical config layout:
+
+```
+# top-level
+let home = /^\/home\/you(\/.*)?$/
+audit file "/tmp/claude-tool-use.json" level matched
+
+# (paste injection-guard let-vars here, if any)
+
+table input default passthrough {
+    Bash -> forward bash_commands
+    # (paste mcp-common-allowlist rules here)
+}
+
+table bash_commands default passthrough {
+    # (paste injection-guards rules first — denies must come early)
+    # (paste shell-wrappers rules)
+    # (paste git-safe, kubectl-readonly, etc.)
+    # (paste curl-restricted, systemctl-readonly)
+    command /^(pip3?|python3?|npm|npx|node|bun|tsx?)\b/ -> forward scripting_languages
+}
+
+# (paste git_worktree table from git-safe.perm)
+# (paste scripting_languages table from scripting-venv.perm)
+```
+
+After editing, validate:
+
+```sh
+permiter validate -c ~/.config/permiter.perm
+```
+
+And spot-check rules:
+
+```sh
+permiter check -c ~/.config/permiter.perm --tool Bash --command "git status"
+```

--- a/contrib/curl-restricted.perm
+++ b/contrib/curl-restricted.perm
@@ -1,0 +1,22 @@
+# curl-restricted.perm
+#
+# Allow `curl` only to localhost or to read-only GitHub API endpoints.
+# Anything else (arbitrary internet, write methods, etc.) passes
+# through so Claude Code prompts you.
+#
+# Drop into: top-level (the `let`s) + table bash_commands { ... }
+
+let localhost_url     = /https?:\/\/(localhost|127\.0\.0\.1|\[::1\])/
+let curl_write_flags  = /^(-X|--request|--data|-d|-F|--form|-T|--upload-file)$/
+
+# ─── In table bash_commands ───────────────────────────────────────
+
+# Localhost is always fine — your own dev servers.
+command /^curl\b/ arg $localhost_url -> allow "curl to localhost"
+
+# Read-only GitHub API: matches https://api.github.com/... but only
+# if no write-mode flag is present in the args.
+command /^curl\b/ !arg $curl_write_flags arg /^https:\/\/api\.github\.com\// -> allow "curl read-only GitHub API"
+
+# Anything else (curl https://untrusted.example/, POST to api.github.com,
+# etc.) falls through to passthrough.

--- a/contrib/git-safe.perm
+++ b/contrib/git-safe.perm
@@ -1,0 +1,29 @@
+# git-safe.perm
+#
+# Allow read-only git subcommands; route `git worktree` to a sub-table
+# with finer-grained control; let everything else pass through.
+#
+# Drop into: table bash_commands { ... }
+# Plus: paste the git_worktree table at the top level.
+
+# Read-only and low-risk subcommands. Add/remove to taste — `commit`
+# is included on the assumption that you want the agent to commit
+# its own work; remove if not.
+command /^git\b/ arg /^(ls-files|bisect|blame|branch|commit|tag|pull|fetch|diff|log|grep|show|status|stash)\b/ -> allow "Safe git subcommand"
+
+# `git -C <dir> worktree …` and bare `git worktree …` both routed.
+command /^git(\s+-C\s+\S+)?\s+worktree\b/ -> forward git_worktree
+
+# Anything else (push, reset --hard, rebase -i, ...) falls through
+# to passthrough so Claude Code prompts you.
+
+# ─── Paste at top level (sibling of bash_commands) ─────────────────
+
+table git_worktree default passthrough {
+    command /git(\s+-C\s+\S+)?\s+worktree\s+(add|lock|unlock|repair|list)\b/ -> allow "Safe git worktree subcommand"
+
+    # Unknown worktree subcommand: passthrough so Claude prompts.
+    # Use `force passthrough` instead if you want to prevent local
+    # rules from upgrading these to allow.
+    command /git.*worktree/ -> passthrough "Unrecognised git worktree subcommand"
+}

--- a/contrib/injection-guards.perm
+++ b/contrib/injection-guards.perm
@@ -1,0 +1,27 @@
+# injection-guards.perm
+#
+# Defensive denies that should appear at the TOP of your bash_commands
+# table — order matters because permiter takes the first matching rule.
+#
+# Drop into: table bash_commands { ... }
+
+# Newline embedded in a quoted argument can hide subsequent args from
+# arg/path validation. Example: `cat "safe\n# evil" /etc/shadow` would
+# parse as a single argument containing a newline. Block it outright.
+command /\n/ -> deny "newline in argument — possible injection"
+
+# SSH / SCP / SFTP — outbound shell access is rarely what an agent
+# should be doing unattended.
+command /^(ssh|sftp|scp)\b/ -> deny "SSH/SCP/SFTP not allowed"
+
+# sudo prompts interactively for a password, which deadlocks an
+# agent session. Build a passwordless wrapper for any specific
+# elevated workflow you actually need.
+command /^sudo\b/ -> deny "sudo not allowed — interactive password prompt breaks in Claude Code"
+
+# Disk-level destructive tools — almost never the right answer
+# from an agent.
+command /^(dd|mkfs|fdisk|parted|shred|wipefs)\b/ -> deny "Disk manipulation not allowed"
+
+# Pipe-curl-to-shell pattern — classic supply-chain footgun.
+command /^(curl|wget)\b.*\|\s*(sh|bash|zsh)\b/ -> deny "Piping downloads to shell not allowed"

--- a/contrib/kubectl-readonly.perm
+++ b/contrib/kubectl-readonly.perm
@@ -1,0 +1,22 @@
+# kubectl-readonly.perm
+#
+# Allow non-destructive kubectl subcommands; let mutations
+# (create/apply/delete/patch/scale/...) fall through to passthrough.
+#
+# Drop into: top-level (the `let`) + table bash_commands { ... }
+
+let safe_kube = /^kubectl (explain|get|cluster-info|top|describe|logs|attach|exec|cp|auth|debug|events|diff)\b/
+
+# ─── In table bash_commands ───────────────────────────────────────
+
+command $safe_kube -> allow "Non-destructive kubectl"
+
+# Anything else (kubectl delete, apply, patch, scale, edit, …)
+# falls through to passthrough so Claude prompts.
+
+# Notes:
+# - `attach` and `exec` are in the read-only list because they don't
+#   mutate cluster state, but they DO let you run arbitrary commands
+#   inside a pod. Remove them if that's not what you want.
+# - `cp` lets you copy files into a pod. Remove if you only want
+#   inspection-grade access.

--- a/contrib/mcp-common-allowlist.perm
+++ b/contrib/mcp-common-allowlist.perm
@@ -1,0 +1,30 @@
+# mcp-common-allowlist.perm
+#
+# Allow common MCP servers by tool-name prefix. MCP tools are surfaced
+# to Claude Code as `mcp__<server>__<tool>`, so prefix matching covers
+# every tool from a server in one rule.
+#
+# Drop into: table input { ... } (or whichever table fronts your
+# non-Bash routing).
+#
+# Pick and choose — only allow servers you actually trust to act
+# autonomously.
+
+# Browser / page automation
+tool /^mcp__playwright-/        -> allow "playwright MCP"
+tool /^mcp__devtools__/         -> allow "Chrome devtools MCP"
+tool /^mcp__web-inspector__/    -> allow "web-inspector MCP"
+
+# Reasoning / docs
+tool /^mcp__sequential-thinking__/ -> allow "sequential-thinking MCP"
+tool /^mcp__systems-thinking__/    -> allow "systems-thinking MCP"
+tool /^mcp__context7__/            -> allow "context7 docs MCP"
+
+# GitHub MCP — split read-only vs write so writes get a prompt.
+tool /^mcp__github__(get_|list_|search_)/ -> allow "GitHub MCP read-only"
+tool /^mcp__github__/                     -> passthrough "GitHub MCP write needs review"
+
+# Notes / data — adjust if your servers have different names.
+tool /^mcp__claude-notes__/ -> allow "claude-notes MCP"
+tool /^mcp__clickup__/      -> allow "ClickUp MCP"
+tool /^mcp__neo4j__/        -> allow "Neo4j MCP"

--- a/contrib/scripting-venv.perm
+++ b/contrib/scripting-venv.perm
@@ -1,0 +1,42 @@
+# scripting-venv.perm
+#
+# Allow Python / Node / Bun tooling only when the project clearly
+# IS a Python / Node / Bun project — detected by checking for a
+# venv directory, package.json, or bun lockfile relative to cwd.
+#
+# `has_file` walks up to the git root, so the check works from any
+# subdirectory of the project.
+#
+# Drop into: bash_commands forward rules + a scripting_languages
+# table at top level.
+
+# ─── In table bash_commands ───────────────────────────────────────
+
+# Forward to the dedicated table so the rest of bash_commands stays clean.
+command /^(pip3?|python3?)\b/ -> forward scripting_languages
+command /(^|\/)\.venv\/bin\// -> forward scripting_languages
+command /^(npm|npx|node|tsx|ts-node|bun)\b/ -> forward scripting_languages
+command /^\.\/node_modules\// -> forward scripting_languages
+
+# ─── Paste at top level (sibling of bash_commands) ─────────────────
+
+table scripting_languages default passthrough {
+    # Explicit venv / node_modules paths — the binary itself is scoped.
+    command /(^|\/)\.venv\/bin\// -> allow "venv binary"
+    command /^\.\/node_modules\/\.bin\// -> allow "local node_modules binary"
+
+    # Bare `pip` / `python` only when a project venv exists.
+    command /^pip3?\b/    has_file ".venv/bin/pip"    -> allow "pip (venv exists)"
+    command /^python3?\b/ has_file ".venv/bin/python" -> allow "python (venv exists)"
+
+    # Node / TS only when package.json exists.
+    command /^npm\b/     has_file "package.json" -> allow "npm (has package.json)"
+    command /^npx\b/     has_file "package.json" -> allow "npx (has package.json)"
+    command /^node\b/    has_file "package.json" -> allow "node (has package.json)"
+    command /^tsx?\b/    has_file "package.json" -> allow "tsx (has package.json)"
+    command /^ts-node\b/ has_file "package.json" -> allow "ts-node (has package.json)"
+
+    # Bun only when a bun lockfile / config is present.
+    command /^bun\b/ has_file "bun.lockb"   -> allow "bun (has bun.lockb)"
+    command /^bun\b/ has_file "bunfig.toml" -> allow "bun (has bunfig.toml)"
+}

--- a/contrib/shell-wrappers.perm
+++ b/contrib/shell-wrappers.perm
@@ -1,0 +1,40 @@
+# shell-wrappers.perm
+#
+# `evaluate` rules unwrap a wrapper command and re-feed the inner
+# command back through the rules engine, so `timeout 5 rm /tmp/x`
+# is evaluated as `rm /tmp/x` against your normal rules.
+#
+# Drop into: table bash_commands { ... }
+#
+# Without these, every wrapped invocation of an otherwise-allowed
+# command falls through to passthrough, which is annoying.
+
+# Shell -c: the inner -c argument is itself a shell command line.
+# permiter parses it and evaluates each sub-command independently.
+command /^(sh|bash|zsh|dash)\b/ -> evaluate flag -c
+
+# Position-based wrappers: skip N positional args, treat the rest
+# as the inner command.
+command /^time\b/      -> evaluate skip 0
+command /^timeout\b/   -> evaluate skip 1
+command /^command\b/   -> evaluate skip 1
+
+# Wrappers that take their own flags before the inner command.
+command /^xargs\b/     -> evaluate skip 0 opts [-I, -n, -P, -s, -d, -L, -a]
+command /^watch\b/     -> evaluate skip 0 opts [-n, -d, -g, -e, -c]
+command /^(nice|ionice)\b/ -> evaluate skip 0 opts [-n]
+command /^stdbuf\b/    -> evaluate skip 0 opts [-i, -o, -e]
+command /^env\b/       -> evaluate skip 0 opts [-i, -u, -C]
+command /^flock\b/     -> evaluate skip 1 opts [-w, -E]
+
+# Shell control flow: `while CMD; do ... done` — evaluate CMD as
+# its own command. Body commands are decomposed separately.
+command /^(while|until|if)\b/ -> evaluate skip 0
+
+# Shell keywords that just join a parsed compound — safe to allow
+# bare since the actual commands inside are evaluated separately.
+command /^(for|do|done|then|else|elif|fi|case|esac)\b/ -> allow "Shell keyword"
+
+# Shell builtins with no security impact on their own.
+command /^(cd|read|test)\b/ -> allow "Shell builtins"
+command /^\[\b/             -> allow "Test bracket"

--- a/contrib/systemctl-readonly.perm
+++ b/contrib/systemctl-readonly.perm
@@ -1,0 +1,13 @@
+# systemctl-readonly.perm
+#
+# Allow `systemctl status / show / list-* / cat / is-active / ...` —
+# the inspection subcommands. Anything that mutates unit state
+# (start, stop, restart, enable, disable, reload, daemon-reload,
+# mask, edit) passes through so Claude Code prompts you.
+#
+# Drop into: table bash_commands { ... }
+
+command /^systemctl\b/ arg /^(status|list-units|list-sockets|list-timers|list-jobs|list-machines|list-dependencies|show|show-environment|cat|is-active|is-enabled|is-failed|get-default)$/ -> allow "systemctl read-only"
+
+# Mutations fall through to passthrough.
+command /^systemctl\b/ -> passthrough "systemctl mutation needs review"

--- a/skills/permiter/SKILL.md
+++ b/skills/permiter/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: permiter
+description: Use when the user mentions permiter, asks to add/edit a permiter rule, references the permiter config, or asks why a command is blocked/allowed by permiter. Do NOT use for generic Claude Code settings.json questions.
+---
+
+# permiter
+
+permiter is an iptables-inspired `PreToolUse` hook for Claude Code. It intercepts every tool call, decomposes compound shell commands into sub-commands (splitting on `&&`, `|`, `;`, `$(...)`, etc.), and evaluates each independently against a chain of rule tables. The strictest result across all sub-commands wins.
+
+## Key locations
+
+| | Path |
+|-|------|
+| Binary | `/home/dave/dev/permiter/target/release/permiter` |
+| Global config | `/home/dave/.config/permiter.perm` |
+| Audit log | `/tmp/claude-tool-use.json` |
+| Project rules | `.permiter/*.perm` in project root |
+
+## Adding rules
+
+**Project-local rule** (applies only in this repo):
+
+1. Create `.permiter/<name>.perm` in the project root — **not** `settings.local.json`
+2. Add `.permiter/` to `.gitignore`
+3. Verify with `permiter check` (see Testing)
+
+```
+# .permiter/project.perm
+Bash command /^npm run build\b/ -> allow "npm run build"
+Bash command /^kubectl\b/ -> allow "all kubectl"
+```
+
+**Global rule** (applies everywhere): edit `/home/dave/.config/permiter.perm`
+
+`settings.local.json` Bash entries have no effect — permiter intercepts before Claude Code's permission check runs. Any `Bash(...)` entries there are vestigial.
+
+## Rule DSL syntax
+
+```
+[Tool] [conditions...] -> action ["reason"]
+```
+
+**Tool** — bare name is exact match (`Bash`, `Read`, `Write`, `Edit`, `Glob`). Omit to match any tool.
+
+**Conditions:**
+
+| Field | Matches |
+|-------|---------|
+| `command /regex/` | Full sub-command string (Bash) |
+| `arg /regex/` | Any individual argument |
+| `file_path /regex/` | File path (Read/Write/Edit/Glob) |
+| `cwd /regex/` | Effective working directory |
+| `has_file "path"` | Relative path exists (walks up to git root) |
+
+Prefix any condition with `!` to negate: `!arg /^--insecure$/`
+
+**Variables** — reusable regex fragments:
+```
+let safe_cmds = /^(ls|pwd|echo)\b/
+Bash command $safe_cmds -> allow "safe"
+```
+
+**Actions:**
+
+| Action | Effect |
+|--------|--------|
+| `allow` | Permit |
+| `deny` | Block (Claude sees an error) |
+| `passthrough` | No opinion — Claude Code decides |
+| `force passthrough` | Passthrough that local rules cannot override |
+| `forward table_name` | Delegate to another table |
+| `evaluate flag -c` | Extract subcommand from `-c` flag and re-evaluate |
+| `evaluate skip N` | Skip N positional args, treat rest as subcommand |
+
+**Decision strictness** (for compound commands): `deny > force passthrough > passthrough > allow`
+
+## Local rules
+
+Local rules fire **only when the global config returns `passthrough`** — they cannot override a global `allow` or `deny`.
+
+Restrictions in local rules (enforced by permiter):
+- Actions: `allow`, `deny`, `passthrough` only
+- No `forward`, `evaluate`, `force passthrough`, tables, `entry`, or `audit`
+- DSL `.perm` format only; `let` variables are allowed
+
+## Testing rules
+
+Always run `permiter check` **from inside the project directory** (local rules are resolved from cwd):
+
+```bash
+cd /path/to/project
+/home/dave/dev/permiter/target/release/permiter check \
+  -c /home/dave/.config/permiter.perm \
+  --tool Bash --command "kubectl delete pod foo"
+# → Decision: ALLOW  Source: .permiter/
+```
+
+Also test the **negative case** from outside the project to confirm scope:
+```bash
+cd /tmp
+/home/dave/dev/permiter/target/release/permiter check \
+  -c /home/dave/.config/permiter.perm \
+  --tool Bash --command "kubectl delete pod foo"
+# → Decision: PASSTHROUGH  (local rule did not fire)
+```
+
+Other tools use `--file_path` instead of `--command`:
+```bash
+permiter check -c ... --tool Read --file_path "/etc/passwd"
+```
+
+## Diagnosing a blocked or passthroughed command
+
+### Audit log (what actually happened)
+
+The audit log at `/tmp/claude-tool-use.json` records every rule match as JSON lines. Each line is one evaluated sub-command:
+
+```json
+{"timestamp":"2026-01-01T12:00:00Z","tool":"Bash","field":"command","check_string":"rm -rf /","cwd":"/home/dave/project","decision":"deny","reason":"rm is not allowed","table":"shell_scrutiny","rule_index":0,"source":"global"}
+```
+
+**To find which sub-command in a compound bash command went to passthrough:**
+
+```bash
+# Last N decisions — shows each decomposed sub-command separately
+tail -n 50 /tmp/claude-tool-use.json | jq -r '
+  [.timestamp, .decision, .check_string, .reason // ""] | @tsv
+'
+
+# Filter to just passthrough decisions
+tail -n 100 /tmp/claude-tool-use.json | jq -r '
+  select(.decision == "passthrough") |
+  [.timestamp, .check_string, .table, .reason // ""] | @tsv
+'
+
+# Show the full last command's sub-commands (group by timestamp proximity)
+tail -n 20 /tmp/claude-tool-use.json | jq -r '
+  [.decision, .check_string] | @tsv
+'
+```
+
+The `check_string` field is the exact sub-command that was evaluated. For a compound command like `cd /tmp && rm file && echo done`, you'll see three separate entries.
+
+### Verbose rule trace
+
+For a detailed trace of which rule matched and why:
+```bash
+RUST_LOG=debug /home/dave/dev/permiter/target/release/permiter check \
+  -c /home/dave/.config/permiter.perm \
+  --tool Bash --command "your full compound command"
+```
+
+This shows every sub-command permiter decomposed out of the compound command, which table and rule matched each one, and the final merged decision.

--- a/src/shell_parser.rs
+++ b/src/shell_parser.rs
@@ -209,9 +209,19 @@ impl Parser {
                     self.advance();
                     if self.peek() == Some('<') {
                         self.advance();
-                        // heredoc: capture delimiter but don't treat body as commands
+                        // heredoc: for shells, parse the body as commands (closing security gap
+                        // where `bash << 'EOF'\nrm -rf /\nEOF` was silently skipped).
+                        // For non-shell programs (python3, etc.) just skip — the caller's
+                        // normal rules cover the command itself and we don't process the body.
                         let delim = self.read_word();
-                        self.skip_heredoc(&delim);
+                        if is_shell_program(&words) {
+                            let body = self.extract_heredoc_body(&delim);
+                            let sub_cwd = self.cwd.clone();
+                            let sub_cmds = parse_commands(&body, &sub_cwd);
+                            self.commands.extend(sub_cmds);
+                        } else {
+                            self.skip_heredoc(&delim);
+                        }
                         break;
                     } else if self.peek() == Some('&') {
                         // <&N — fd-to-fd input redirect; consume and ignore
@@ -520,6 +530,42 @@ impl Parser {
             }
         }
     }
+
+    /// Extract and return the heredoc body as a string (rather than discarding it).
+    /// Used for shell programs so the body can be re-parsed as commands.
+    fn extract_heredoc_body(&mut self, delimiter: &str) -> String {
+        let delimiter = delimiter.trim_matches(|c: char| c == '\'' || c == '"');
+        let mut body = String::new();
+        loop {
+            let mut line = String::new();
+            loop {
+                match self.advance() {
+                    None => return body,
+                    Some('\n') => break,
+                    Some(c) => line.push(c),
+                }
+            }
+            if line.trim() == delimiter {
+                return body;
+            }
+            body.push_str(&line);
+            body.push('\n');
+        }
+    }
+}
+
+/// Returns true if the first non-assignment word in `words` is a shell interpreter.
+/// Used to decide whether a heredoc body should be parsed as commands.
+fn is_shell_program(words: &[String]) -> bool {
+    let program = words
+        .iter()
+        .find(|w| {
+            let before_eq = w.split('=').next().unwrap_or("");
+            !(w.contains('=') && before_eq.chars().all(|c| c.is_alphanumeric() || c == '_'))
+        })
+        .map(|s| s.as_str())
+        .unwrap_or("");
+    matches!(program, "sh" | "bash" | "zsh" | "dash")
 }
 
 /// Resolve a path relative to cwd. Handles ~, ., ..


### PR DESCRIPTION
## Summary
- Parse heredoc bodies as commands when fed to a shell (`bash << EOF ... EOF`) so rules apply instead of falling silently to the table default. Non-shell programs (`cat`, `python3`) keep skipping their heredoc body.
- Add a bundled Claude Code skill (`skills/permiter/SKILL.md`) covering DSL syntax, local vs global rules, testing with `permiter check`, and audit-log diagnostics.
- Add `contrib/` directory with copy-pasteable rule snippets (injection guards, shell wrappers, git, kubectl, scripting venvs, curl, systemctl, MCP allowlist) plus a contrib README. Linked from the main README.
- Bump to `0.2.0`.

## Test plan
- [x] `cargo test` — 256 tests pass (219 unit + 37 integration)
- [x] `permiter validate` against my live config still parses
- [x] `permiter check` smoke tests for the new heredoc behaviour and unchanged paths
- [ ] After merge: tag `v0.2.0`, confirm release workflow uploads tarballs for the three targets, update homebrew tap formula